### PR TITLE
WIP: Fix Objective-C syntax highlighting

### DIFF
--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -89,6 +89,7 @@ module Rouge
 
       state :message_shared do
         rule /\]/, Punctuation, :pop!
+        rule /\{/, Punctuation, :pop!
         rule /;/, Error
 
         mixin :statement
@@ -111,6 +112,7 @@ module Rouge
       state :message_with_args do
         rule /(#{id})(\s*)(:)/ do
           groups(Name::Function, Text, Punctuation)
+          pop!
         end
 
         mixin :message_shared
@@ -137,6 +139,7 @@ module Rouge
                  Punctuation, Text,
                  Name::Label, Text,
                  Punctuation)
+          pop!
         end
 
         rule id, Name::Class, :pop!

--- a/spec/visual/samples/objective_c
+++ b/spec/visual/samples/objective_c
@@ -137,3 +137,14 @@ if ([_myDelegate2 respondsToSelector:@selector(doOtherStuff:andText:andType:)])
 {
   NSLog(@" YES VALUE IS %f and text %@ and type %@",myValue2,myText,myType);
 }end
+
+@interface HUDView (SubclassingHooks)
+- (void)updatePageLabelFrameAnimated:(BOOL)animated;
+- (void)updateThumbnailBarFrameAnimated:(BOOL)animated;
+- (void)updateScrubberBarFrameAnimated:(BOOL)animated;
+@end
+
+ViewController *controller = [[ViewController alloc] initWithDocument:document configuration:[Configuration configurationWithBuilder:^(ConfigurationBuilder *builder) {
+    builder.thumbnailBarMode = ThumbnailBarModeScrollable;
+    builder.pageLabelEnabled = NO;
+}]];


### PR DESCRIPTION
I added some extra snippets to ` spec/visual/samples/objective_c` to demonstrate the problem:

```shell
- git clone git@github.com:PSPDFKit-labs/rouge.git
- cd rouge
- git checkout william/objc-fixes
- bundle
- rackup
- open http://localhost:9292/objective_c?debug=1
```

The issue is in the Objective-C lexer in `lib/rouge/lexers/objective_c.rb`.

Will fix: 
- jneen/rouge#449
- PSPDFKit/PSPDFKit-Website#278
- PSPDFKit/PSPDFKit-guides#91